### PR TITLE
fix: improve ckmeans performance

### DIFF
--- a/packages/ckmeans-native/src/native/ckmeans.c
+++ b/packages/ckmeans-native/src/native/ckmeans.c
@@ -68,7 +68,7 @@ void fillMatrixColumn(size_t imin, size_t imax, size_t column, size_t nColumns, 
     jlow = max_t(jlow, backtrackMatrix[(column -1)* nRows + i]);
 
     size_t jhigh = i - 1;
-    if (imax < nColumns - 1) {
+    if (imax < nRows - 1) {
         jhigh = min_t(jhigh, backtrackMatrix[column * nRows + imax + 1]);
     }
 

--- a/packages/ckmeans/src/ckmeans.js
+++ b/packages/ckmeans/src/ckmeans.js
@@ -96,7 +96,7 @@ function fillMatrixColumn(imin, imax, column, matrix, backtrackMatrix, sumX, sum
   jlow = Math.max(jlow, backtrackMatrix[column - 1][i] || 0);
 
   var jhigh = i - 1; // the upper end for j
-  if (imax < matrix.length - 1) {
+  if (imax < matrix[0].length - 1) {
     jhigh = Math.min(jhigh, backtrackMatrix[column][imax + 1] || 0);
   }
 


### PR DESCRIPTION
There's a mistake in the port from the C code that makes impacts performance quite a lot.

Also see https://github.com/simple-statistics/simple-statistics/pull/521 and https://github.com/simple-statistics/simple-statistics/issues/520 for more information.

I ran benchmarks before and after, with massively improved results:

## ckmeans
### Before
```
Benchmarking length 10: 0.497ms
Benchmarking length 100: 3.998ms
Benchmarking length 1000: 8.313ms
Benchmarking length 10000: 175.065ms
Benchmarking length 100000: 16463.141ms
```

### After
```
Benchmarking length 10: 0.904ms
Benchmarking length 100: 4.082ms
Benchmarking length 1000: 21.202ms
Benchmarking length 10000: 39.279ms
Benchmarking length 100000: 311.085ms
```

## ckmeans-native
### Before
```
Benchmarking length 10: 2.971ms
Benchmarking length 100: 0.091ms
Benchmarking length 1000: 1.859ms
Benchmarking length 10000: 137.803ms
Benchmarking length 100000: 16331.004ms
```

### After
```
Benchmarking length 10: 0.245ms
Benchmarking length 100: 0.117ms
Benchmarking length 1000: 0.495ms
Benchmarking length 10000: 4.968ms
Benchmarking length 100000: 51.428ms
```